### PR TITLE
fix(RefreshGroupDataset): keep polling when refresh not yet in history

### DIFF
--- a/src/main/java/io/kestra/plugin/powerbi/RefreshGroupDataset.java
+++ b/src/main/java/io/kestra/plugin/powerbi/RefreshGroupDataset.java
@@ -157,7 +157,8 @@ public class RefreshGroupDataset extends AbstractPowerBi implements RunnableTask
                     .findFirst();
 
                 if (refresh.isEmpty()) {
-                    throw new IllegalStateException("Unable to find refresh '" + refreshId.get() + "'");
+                    logger.debug("Refresh '{}' not yet present in history, waiting...", refreshId.get());
+                    return null;
                 }
 
                 if (logger.isTraceEnabled()) {


### PR DESCRIPTION
### What changes are being made and why?

`RefreshGroupDataset` was failing intermittently with `IllegalStateException: Unable to find refresh '<id>'` when `wait: true`.

The POST `/datasets/{id}/refreshes` call returns the `requestId` immediately, but the refresh does not always appear in the GET refresh history right away (observed propagation delay ~150–200 ms). The wait loop polled the history, didn't find the just-created `requestId`, and threw `IllegalStateException`. Since this runs inside `Await.until`, the exception was treated as a hard failure instead of "not ready yet", so the task failed even though the refresh was healthy.

This PR changes the not-found branch to return `null` (continue polling) instead of throwing — consistent with the existing `status == "Unknown"` handling — so `Await.until` keeps polling until `waitDuration`. If the refresh truly never appears, the standard timeout still applies.

closes #76

---

### How the changes have been QAed?

`RefreshGroupDatasetTest` (wait + no-wait cases) still passes with the mock returning the refresh in history. In production, the flow that previously failed now polls until the refresh shows up and completes:

```yaml
id: refresh-powerbi-dataset
namespace: company.team

tasks:
  - id: refresh_sales_model
    type: io.kestra.plugin.powerbi.RefreshGroupDataset
    tenantId: "{{ secret('AZURE_TENANT_ID') }}"
    clientId: "{{ secret('AZURE_CLIENT_ID') }}"
    clientSecret: "{{ secret('AZURE_CLIENT_SECRET') }}"
    groupId: "{{ secret('PBI_GROUPE_ID') }}"
    datasetId: "{{ secret('PBI_DATASET_ID') }}"
    wait: true
    pollDuration: "PT5M"
    waitDuration: "PT10M"